### PR TITLE
Update sorting

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@web-chapter/ui",
-    "version": "0.0.41",
+    "version": "0.0.42",
     "files": [
         "dist"
     ],

--- a/packages/ui/src/hooks/useTable/useTable.ts
+++ b/packages/ui/src/hooks/useTable/useTable.ts
@@ -221,8 +221,8 @@ export default function useTable<T extends GenericRowStructure>({
     const filteredRows = useMemo(() => applyFiltering(), [applyFiltering]);
 
     const currentPageRows = useMemo(() => {
-        const slicedRows = applyPageSplitting(filteredRows);
-        return applySorting(slicedRows);
+        const sortedRows = applySorting(filteredRows);
+        return applyPageSplitting(sortedRows);
     }, [filteredRows, applySorting, applyPageSplitting]);
 
     return {


### PR DESCRIPTION
Update sorting to take place before pagination. 
This should sort the whole data and then paginate as opposed to the current behaviour where only the data on the current page is sorted.