### PR TITLE
Table/refactor rows per page handler

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@web-chapter/ui",
-    "version": "0.0.43",
+    "version": "0.0.44",
     "files": [
         "dist"
     ],

--- a/packages/ui/src/components/Table/BaseTable.tsx
+++ b/packages/ui/src/components/Table/BaseTable.tsx
@@ -87,7 +87,7 @@ export interface BaseTableProps<T extends GenericRowStructure> {
     classes?: Partial<BaseTableClasses>;
     loading?: boolean;
     SpinnerComponent?: JSXElementConstructor<CircularProgressProps>;
-    handleRowsPerPageChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    handleRowsPerPageChange?: (value: number) => void;
     handlePageChange?: (e: MouseEvent<HTMLButtonElement> | null, newPage: number) => void;
     handleSortCellClick?: (cellId: CellId<T>) => void;
 }
@@ -223,7 +223,7 @@ const BaseTable = <T extends GenericRowStructure>({
                             },
                         }}
                         onPageChange={handleChangePage}
-                        onRowsPerPageChange={handleRowsPerPageChange}
+                        onRowsPerPageChange={(e) => handleRowsPerPageChange(parseInt(e.target.value, 10))}
                     />
                 </TableRow>
             </TableFooter>

--- a/packages/ui/src/components/Table/types.ts
+++ b/packages/ui/src/components/Table/types.ts
@@ -70,7 +70,7 @@ export interface RowAction<T extends GenericRowStructure> {
     disabled?: (row: Row<T>) => boolean;
 }
 
-export type RowsPerPageChangeHandler = (event: ChangeEvent<HTMLInputElement>) => void;
+export type RowsPerPageChangeHandler = (value: number) => void;
 
 export type PageChangeHandler = (_e: MouseEvent<HTMLButtonElement> | null, newPage: number) => void;
 

--- a/packages/ui/src/hooks/useTable/useTable.ts
+++ b/packages/ui/src/hooks/useTable/useTable.ts
@@ -1,5 +1,5 @@
 import { SortDirection } from '@mui/material';
-import { ChangeEvent, MouseEvent, useCallback, useMemo, useReducer } from 'react';
+import { MouseEvent, useCallback, useMemo, useReducer } from 'react';
 
 import type { BaseTableProps } from '../../components/Table/BaseTable';
 import {
@@ -163,9 +163,8 @@ export default function useTable<T extends GenericRowStructure>({
         updateState({ selectedRowIds: updatedSelectedRows });
     };
 
-    const handleRowsPerPageChangeInternal = (event: ChangeEvent<HTMLInputElement>) => {
-        const updatedRowsPerPage = parseInt(event.target.value, 10);
-        updateState({ rowsPerPage: updatedRowsPerPage, page: 0 });
+    const handleRowsPerPageChangeInternal = (value: number) => {
+        updateState({ rowsPerPage: value, page: 0 });
     };
 
     const handleSortCellClickInternal = (cellId: CellId<T>) => {


### PR DESCRIPTION
Switched the handler to use a number as parameter for extensability. 

This will allow custom components not to be bounded to only ChangeEvent<HTMLInputElement>.