### PR TITLE
fix-handleClose-table

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@web-chapter/ui",
-    "version": "0.0.56",
+    "version": "0.0.57",
     "files": [
         "dist"
     ],

--- a/packages/ui/src/components/Table/components/EllipsisCellContent.tsx
+++ b/packages/ui/src/components/Table/components/EllipsisCellContent.tsx
@@ -66,7 +66,7 @@ const EllipsisCellContent = <T extends GenericRowStructure>({
                     id={menuId}
                     open={open}
                     onClose={(e: MouseEvent<HTMLElement>) => {
-                        e?.stopPropagation();
+                        e.stopPropagation();
                         handleClose();
                     }}
                     anchorEl={anchorEl}

--- a/packages/ui/src/components/Table/components/EllipsisCellContent.tsx
+++ b/packages/ui/src/components/Table/components/EllipsisCellContent.tsx
@@ -61,7 +61,16 @@ const EllipsisCellContent = <T extends GenericRowStructure>({
                 >
                     {icon ?? <MoreHorizIcon fontSize="small" />}
                 </IconButton>
-                <Menu classes={classes.menu} id={menuId} open={open} onClose={handleClose} anchorEl={anchorEl}>
+                <Menu
+                    classes={classes.menu}
+                    id={menuId}
+                    open={open}
+                    onClose={(e: MouseEvent<HTMLElement>) => {
+                        e?.stopPropagation();
+                        handleClose();
+                    }}
+                    anchorEl={anchorEl}
+                >
                     {rowActions.map((rowAction) => {
                         const key = `${row.cells.id.value}-${rowAction.id}`;
 


### PR DESCRIPTION
We have a bug on Magmo when we close the menu on the TableRow. Check video below.
You can reproduce the bug on the storybook on the TableStories - Row Actions. Try to open the menu on a table row. And press somewhere outside the table. You'll see that the row action is called even though you didn't actually pressed the row.


https://github.com/coremaker/web-chapter/assets/44604753/e37ffd4a-c832-4633-acde-85a370d1fcb8

